### PR TITLE
Aligned text to left on map layout 2, #122627091

### DIFF
--- a/widget/assets/css/widget.app.css
+++ b/widget/assets/css/widget.app.css
@@ -676,7 +676,7 @@ html[browser="Firefox"] .layout3 .list-layout .list-item-media .list-media-holde
     background-color: rgba(0,0,0,0.3);
     text-decoration: none;
     border-radius: 3.2rem;
-    text-align: center;
+    /*text-align: center;*/
     /*cursor: pointer;*/
 }
 .showBack {


### PR DESCRIPTION
Text made towards left instead of center on widget map layout as per WF, #122627091