### PR TITLE
Places: Items will not load after Filtering items

### DIFF
--- a/widget/controllers/widget.sectionsItems.controller.js
+++ b/widget/controllers/widget.sectionsItems.controller.js
@@ -701,6 +701,7 @@
                     var id = WidgetSections.sections[ind].id;
                     if (WidgetSections.selectedSections && WidgetSections.selectedSections.indexOf(id) < 0) {
                         WidgetSections.selectedSections.push(id);
+                        WidgetSections.selectedSection = id;
                     }
                     else if (WidgetSections.selectedSections) {
                         WidgetSections.selectedSections.splice(WidgetSections.selectedSections.indexOf(id), 1);


### PR DESCRIPTION
When you go into a places plugin, then filter the items based on a category, the items will not load and just show a white screen. 
